### PR TITLE
Add custom apps for encoding OC-RPOL config

### DIFF
--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-22-ydk.py
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-22-ydk.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model openconfig-routing-policy.
+
+usage: cd-encode-config-routing-policy-22-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+from ydk.types import Empty
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure routing policy
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY1"
+    statement = policy_definition.statements.Statement()
+    statement.name = "accept route"
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-22-ydk.txt
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-22-ydk.txt
@@ -1,0 +1,6 @@
+route-policy POLICY1
+  #statement-name accept route
+  done
+end-policy
+!
+end

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-22-ydk.xml
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-22-ydk.xml
@@ -1,0 +1,16 @@
+<routing-policy xmlns="http://openconfig.net/yang/routing-policy">
+  <policy-definitions>
+    <policy-definition>
+      <name>POLICY1</name>
+      <statements>
+        <statement>
+          <name>accept route</name>
+          <actions>
+            <accept-route></accept-route>
+          </actions>
+        </statement>
+      </statements>
+    </policy-definition>
+  </policy-definitions>
+</routing-policy>
+

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-24-ydk.py
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-24-ydk.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model openconfig-routing-policy.
+
+usage: cd-encode-config-routing-policy-24-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+from ydk.types import Empty
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure as-path set
+    bgp_defined_sets = routing_policy.defined_sets.bgp_defined_sets
+    as_path_set = bgp_defined_sets.as_path_sets.AsPathSet()
+    as_path_set.as_path_set_name = "AS-PATH-SET1"
+    as_path_set.as_path_set_member.append("^65172")
+    bgp_defined_sets.as_path_sets.as_path_set.append(as_path_set)
+
+    # configure community set
+    bgp_defined_sets = routing_policy.defined_sets.bgp_defined_sets
+    community_set = bgp_defined_sets.community_sets.CommunitySet()
+    community_set.community_set_name = "COMMUNITY-SET1"
+    community_set.community_member.append("ios-regex '^65172:17...$'")
+    community_set.community_member.append("65172:16001")
+    bgp_defined_sets.community_sets.community_set.append(community_set)
+
+    # configure policy definition
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY2"
+    # community-set statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "community-set1"
+    bgp_conditions = statement.conditions.bgp_conditions
+    match_community_set = bgp_conditions.MatchCommunitySet()
+    match_community_set.community_set = "COMMUNITY-SET1"
+    match_set_options = oc_routing_policy.MatchSetOptionsTypeEnum.ALL
+    match_community_set.match_set_options = match_set_options
+    bgp_conditions.match_community_set = match_community_set
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    # as-path-set statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "as-path-set1"
+    bgp_conditions = statement.conditions.bgp_conditions
+    match_as_path_set = bgp_conditions.MatchAsPathSet()
+    match_as_path_set.as_path_set = "AS-PATH-SET1"
+    match_set_options = oc_routing_policy.MatchSetOptionsTypeEnum.ANY
+    match_as_path_set.match_set_options = match_set_options
+    bgp_conditions.match_as_path_set = match_as_path_set
+    statement.actions.bgp_actions.set_local_pref = 50
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    # reject statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "reject route"
+    statement.actions.reject_route = Empty()
+    policy_definition.statements.statement.append(statement)
+
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-24-ydk.txt
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-24-ydk.txt
@@ -1,0 +1,24 @@
+as-path-set AS-PATH-SET1
+  ios-regex '^65172'
+end-set
+!
+community-set COMMUNITY-SET1
+  ios-regex '^65172:17...$',
+  65172:16001
+end-set
+!
+route-policy POLICY2
+  #statement-name community-set1
+  if community matches-every COMMUNITY-SET1 then
+    done
+  endif
+  #statement-name as-path-set1
+  if as-path in AS-PATH-SET1 then
+    set local-preference 50
+    done
+  endif
+  #statement-name reject route
+  drop
+end-policy
+!
+end

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-24-ydk.xml
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-24-ydk.xml
@@ -1,0 +1,64 @@
+<routing-policy xmlns="http://openconfig.net/yang/routing-policy">
+  <defined-sets>
+    <bgp-defined-sets xmlns="http://openconfig.net/yang/bgp-policy">
+      <as-path-sets>
+        <as-path-set>
+          <as-path-set-name>AS-PATH-SET1</as-path-set-name>
+          <as-path-set-member>^65172</as-path-set-member>
+        </as-path-set>
+      </as-path-sets>
+      <community-sets>
+        <community-set>
+          <community-set-name>COMMUNITY-SET1</community-set-name>
+          <community-member>ios-regex '^65172:17...$'</community-member>
+          <community-member>65172:16001</community-member>
+        </community-set>
+      </community-sets>
+    </bgp-defined-sets>
+  </defined-sets>
+  <policy-definitions>
+    <policy-definition>
+      <name>POLICY2</name>
+      <statements>
+        <statement>
+          <name>community-set1</name>
+          <actions>
+            <accept-route></accept-route>
+          </actions>
+          <conditions>
+            <bgp-conditions xmlns="http://openconfig.net/yang/bgp-policy">
+              <match-community-set>
+                <community-set>COMMUNITY-SET1</community-set>
+                <match-set-options>ALL</match-set-options>
+              </match-community-set>
+            </bgp-conditions>
+          </conditions>
+        </statement>
+        <statement>
+          <name>as-path-set1</name>
+          <actions>
+            <accept-route></accept-route>
+            <bgp-actions xmlns="http://openconfig.net/yang/bgp-policy">
+              <set-local-pref>50</set-local-pref>
+            </bgp-actions>
+          </actions>
+          <conditions>
+            <bgp-conditions xmlns="http://openconfig.net/yang/bgp-policy">
+              <match-as-path-set>
+                <as-path-set>AS-PATH-SET1</as-path-set>
+                <match-set-options>ANY</match-set-options>
+              </match-as-path-set>
+            </bgp-conditions>
+          </conditions>
+        </statement>
+        <statement>
+          <name>reject route</name>
+          <actions>
+            <reject-route></reject-route>
+          </actions>
+        </statement>
+      </statements>
+    </policy-definition>
+  </policy-definitions>
+</routing-policy>
+

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-26-ydk.py
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-26-ydk.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model openconfig-routing-policy.
+
+usage: cd-encode-config-routing-policy-26-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+from ydk.types import Empty
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure prefix set
+    prefix_set = routing_policy.defined_sets.prefix_sets.PrefixSet()
+    prefix_set.prefix_set_name = "PREFIX-SET1"
+    prefix = prefix_set.Prefix()
+    prefix.ip_prefix = "10.0.0.0/16"
+    prefix.masklength_range = "24..32"
+    prefix_set.prefix.append(prefix)
+    prefix = prefix_set.Prefix()
+    prefix.ip_prefix = "172.0.0.0/8"
+    prefix.masklength_range = "16..32"
+    prefix_set.prefix.append(prefix)
+    routing_policy.defined_sets.prefix_sets.prefix_set.append(prefix_set)
+
+    # configure community set
+    bgp_defined_sets = routing_policy.defined_sets.bgp_defined_sets
+    community_set = bgp_defined_sets.community_sets.CommunitySet()
+    community_set.community_set_name = "COMMUNITY-SET2"
+    community_set.community_member.append("65172:17001")
+    bgp_defined_sets.community_sets.community_set.append(community_set)
+
+    # configure policy definition
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY3"
+    # prefix-set statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "prefix-set1"
+    match_prefix_set = statement.conditions.MatchPrefixSet()
+    match_prefix_set.prefix_set = "PREFIX-SET1"
+    match_set_options = oc_routing_policy.MatchSetOptionsRestrictedTypeEnum.ANY
+    match_prefix_set.match_set_options = match_set_options
+    statement.conditions.match_prefix_set = match_prefix_set
+    statement.actions.bgp_actions.set_local_pref = 1000
+    set_community = statement.actions.bgp_actions.SetCommunity()
+    set_community.community_set_ref = "COMMUNITY-SET2"
+    statement.actions.bgp_actions.set_community = set_community
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    # reject statement
+    statement = policy_definition.statements.Statement()
+    statement.name = "reject route"
+    statement.actions.reject_route = Empty()
+    policy_definition.statements.statement.append(statement)
+
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-26-ydk.txt
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-26-ydk.txt
@@ -1,0 +1,21 @@
+prefix-set PREFIX-SET1
+  10.0.0.0/16 ge 24 le 32,
+  172.0.0.0/8 ge 16 le 32
+end-set
+!
+community-set COMMUNITY-SET2
+  65172:17001
+end-set
+!
+route-policy POLICY3
+  #statement-name prefix-set1
+  if destination in PREFIX-SET1 then
+    set local-preference 1000
+    set community COMMUNITY-SET2
+    done
+  endif
+  #statement-name reject
+  drop
+end-policy
+!
+end

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-26-ydk.xml
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-26-ydk.xml
@@ -1,0 +1,57 @@
+<routing-policy xmlns="http://openconfig.net/yang/routing-policy">
+  <defined-sets>
+    <bgp-defined-sets xmlns="http://openconfig.net/yang/bgp-policy">
+      <community-sets>
+        <community-set>
+          <community-set-name>COMMUNITY-SET2</community-set-name>
+          <community-member>65172:17001</community-member>
+        </community-set>
+      </community-sets>
+    </bgp-defined-sets>
+    <prefix-sets>
+      <prefix-set>
+        <prefix-set-name>PREFIX-SET1</prefix-set-name>
+        <prefix>
+          <ip-prefix>10.0.0.0/16</ip-prefix>
+          <masklength-range>24..32</masklength-range>
+        </prefix>
+        <prefix>
+          <ip-prefix>172.0.0.0/8</ip-prefix>
+          <masklength-range>16..32</masklength-range>
+        </prefix>
+      </prefix-set>
+    </prefix-sets>
+  </defined-sets>
+  <policy-definitions>
+    <policy-definition>
+      <name>POLICY3</name>
+      <statements>
+        <statement>
+          <name>prefix-set1</name>
+          <actions>
+            <accept-route></accept-route>
+            <bgp-actions xmlns="http://openconfig.net/yang/bgp-policy">
+              <set-community>
+                <community-set-ref>COMMUNITY-SET2</community-set-ref>
+              </set-community>
+              <set-local-pref>1000</set-local-pref>
+            </bgp-actions>
+          </actions>
+          <conditions>
+            <match-prefix-set>
+              <match-set-options>ANY</match-set-options>
+              <prefix-set>PREFIX-SET1</prefix-set>
+            </match-prefix-set>
+          </conditions>
+        </statement>
+        <statement>
+          <name>reject route</name>
+          <actions>
+            <reject-route></reject-route>
+          </actions>
+        </statement>
+      </statements>
+    </policy-definition>
+  </policy-definitions>
+</routing-policy>
+

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-28-ydk.py
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-28-ydk.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Encode config for model openconfig-routing-policy.
+
+usage: cd-encode-config-routing-policy-28-ydk.py [-h] [-v]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --verbose  print debugging messages
+"""
+
+from argparse import ArgumentParser
+from urlparse import urlparse
+
+from ydk.services import CodecService
+from ydk.providers import CodecServiceProvider
+from ydk.models.routing import routing_policy as oc_routing_policy
+from ydk.models.bgp import bgp_policy as oc_bgp_policy
+from ydk.types import Empty
+import logging
+
+
+def config_routing_policy(routing_policy):
+    """Add config data to routing_policy object."""
+    # configure policy definition
+    policy_definition = routing_policy.policy_definitions.PolicyDefinition()
+    policy_definition.name = "POLICY4"
+    statement = policy_definition.statements.Statement()
+    statement.name = "next-hop-self"
+    set_next_hop = oc_bgp_policy.BgpNextHopTypeEnum.SELF
+    statement.actions.bgp_actions.set_next_hop = set_next_hop
+    statement.actions.accept_route = Empty()
+    policy_definition.statements.statement.append(statement)
+    routing_policy.policy_definitions.policy_definition.append(policy_definition)
+
+
+if __name__ == "__main__":
+    """Execute main program."""
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose", help="print debugging messages",
+                        action="store_true")
+    args = parser.parse_args()
+
+    # log debug messages if verbose argument specified
+    if args.verbose:
+        logger = logging.getLogger("ydk")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(("%(asctime)s - %(name)s - "
+                                      "%(levelname)s - %(message)s"))
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    # create codec provider
+    provider = CodecServiceProvider(type="xml")
+
+    # create codec service
+    codec = CodecService()
+
+    routing_policy = oc_routing_policy.RoutingPolicy()  # create config object
+    config_routing_policy(routing_policy)  # add object configuration
+
+    print(codec.encode(provider, routing_policy))  # encode and print object
+    provider.close()
+    exit()
+# End of script

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-28-ydk.txt
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-28-ydk.txt
@@ -1,0 +1,7 @@
+route-policy POLICY4
+  #statement-name next-hop-self
+  set next-hop self
+  done
+end-policy
+!
+end

--- a/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-28-ydk.xml
+++ b/samples/basic/codec/ydk/models/openconfig/cd-encode-config-routing-policy-28-ydk.xml
@@ -1,0 +1,19 @@
+<routing-policy xmlns="http://openconfig.net/yang/routing-policy">
+  <policy-definitions>
+    <policy-definition>
+      <name>POLICY4</name>
+      <statements>
+        <statement>
+          <name>next-hop-self</name>
+          <actions>
+            <accept-route></accept-route>
+            <bgp-actions xmlns="http://openconfig.net/yang/bgp-policy">
+              <set-next-hop>SELF</set-next-hop>
+            </bgp-actions>
+          </actions>
+        </statement>
+      </statements>
+    </policy-definition>
+  </policy-definitions>
+</routing-policy>
+


### PR DESCRIPTION
Four custom apps to encode OpenConfig routing policy configuration. Each
sample app has corresponding XML and CLI outputs. The apps also reuse
the configuration used for the CRUD sample apps.
